### PR TITLE
Simplify installation by including pip dependencies in the yaml

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,11 +62,6 @@ Load the conda environment
 conda activate ardap
 ```
 
-3) Install Resfinder dependencies.
-```
-pip3 install tabulate biopython cgecore gitpython python-dateutil
-```
-
 The pipeline itself is either run by calling the main.nf or from a local respostory in a local nextflow cache. 
 
 Load the conda environment:

--- a/env.yaml
+++ b/env.yaml
@@ -6,7 +6,6 @@ dependencies:
   - trimmomatic
   - bwa
   - bedtools=2.28.0
-  - biopython
   - seqtk
   - pindel
   - delly
@@ -22,8 +21,10 @@ dependencies:
   - kma
   - pip
   - openjdk=8.0
+  - python=3
   - pip:
     - cgecore
+    - biopython
     - gitpython
     - python-dateutil
     - tabulate

--- a/env.yaml
+++ b/env.yaml
@@ -21,6 +21,7 @@ dependencies:
   - bcftools
   - kma
   - pip
+  - openjdk=8.0
   - pip:
     - cgecore
     - gitpython

--- a/env.yaml
+++ b/env.yaml
@@ -6,6 +6,7 @@ dependencies:
   - trimmomatic
   - bwa
   - bedtools=2.28.0
+  - biopython
   - seqtk
   - pindel
   - delly
@@ -19,8 +20,8 @@ dependencies:
   - fasttree
   - bcftools
   - kma
+  - pip
   - pip:
-    - biopython
     - cgecore
     - gitpython
     - python-dateutil

--- a/env.yaml
+++ b/env.yaml
@@ -19,4 +19,9 @@ dependencies:
   - fasttree
   - bcftools
   - kma
-  - pip
+  - pip:
+    - biopython
+    - cgecore
+    - gitpython
+    - python-dateutil
+    - tabulate


### PR DESCRIPTION
Currently, installation requires three steps:

1. `git clone repo`
2. `conda env create -f ./repo/env.yml`
3. `pip install dep1 dep2 dep3`

I revised `env.yml` and the installation instructions to simplify the installation into 2 steps. This is obviously not as convenient as #5 but I think it is still better than the current implementation