### PR TITLE
`bc` is required by `.command.sh` in the MarkDuplicates step

### DIFF
--- a/env.yaml
+++ b/env.yaml
@@ -5,6 +5,7 @@ dependencies:
   - art
   - trimmomatic
   - bwa
+  - bc
   - bedtools=2.28.0
   - seqtk
   - pindel


### PR DESCRIPTION
this is the last change that i needed to run `ARDaP` on my machine.