### PR TITLE
Fix detection of .raw.gvcf files in single-isolate runs

### DIFF
--- a/bin/Master_vcf.sh
+++ b/bin/Master_vcf.sh
@@ -4,7 +4,7 @@ ref=$1
 
 echo "Creating master VCF file"
 
-array=($(find *.gvcf -printf "%f "))
+array=($(find . -name '*.gvcf' -printf '%f '))
 n="${#array[@]}"
 array2=("${array[@]/#/-V }")
 gatk CombineGVCFs -R ${ref}.fasta ${array2[*]} -O master.vcf


### PR DESCRIPTION
In single-isolate runs, the initial find command did not detect the generated .raw.gvcf file. This update adjusts the find pattern to ensure the .raw.gvcf file is correctly detected.